### PR TITLE
Switch the Phoenix6 API for zeroing the encoder

### DIFF
--- a/src/main/cpp/NoteHandler.cpp
+++ b/src/main/cpp/NoteHandler.cpp
@@ -20,8 +20,8 @@ double NoteHandler::getShooterAngle() {
     return a_Shooter.GetShooterAngle();
 }
 
-void NoteHandler::setShooterAngleToDefault() {
-    a_Shooter.setShooterAngle();
+void NoteHandler::UpdateSensors() {
+    a_Shooter.UpdateSensors();
 }
 
 void NoteHandler::startShooter(double rpm, double angle) {

--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -101,7 +101,7 @@ void Robot::RobotInit() {
 void Robot::RobotPeriodic() {
     a_LED.Update();
 
-    a_NoteHandler.setShooterAngleToDefault();
+    a_NoteHandler.UpdateSensors();
 
     
     // if(a_NoteHandler.beamBroken()){

--- a/src/main/include/NoteHandler.h
+++ b/src/main/include/NoteHandler.h
@@ -37,10 +37,9 @@ class NoteHandler {
 
         // Shooter Stuff
         double getShooterAngle();
-        void setShooterAngleToDefault();
         void startShooter(double rpm, double angle);
         void stopShooter();
-        
+
         // Collecter Stuff
         void startCollector(double speed);
         void stopCollector();
@@ -61,6 +60,7 @@ class NoteHandler {
         void dispenseNote();
         bool beamBroken();
 
+        void UpdateSensors();
         void updateDashboard();
         bool shootToAmpMode = false;
         // Interpolation

--- a/src/main/include/Shooter.h
+++ b/src/main/include/Shooter.h
@@ -12,10 +12,10 @@ class Shooter{
         void stopShooter();
         bool moveToAngle(double angle);
         double getSpeed();
-        void setShooterAngle();
+        void UpdateSensors();
         double GetShooterAngle();
     private:
-    
+
         frc::PIDController leftShooterPID;
         frc::PIDController rightShooterPID;
         frc::PIDController pivotPID;
@@ -25,10 +25,8 @@ class Shooter{
         ctre::phoenix6::hardware::TalonFX pivotMotor;
 
         ctre::phoenix6::controls::VelocityVoltage m_request = ctre::phoenix6::controls::VelocityVoltage{0_tps}.WithSlot(0);
-    
-      
-        LimitSwitch shooterLimitSwitch;
+        ctre::phoenix6::controls::DutyCycleOut m_pivotDutyCycleRequest{0.0};
 
-        units::angle::turn_t zeroShooter{units::degree_t{0.0}};
-        bool shooterAlreadyZeroed = false;
+
+        LimitSwitch shooterLimitSwitch;
 };


### PR DESCRIPTION
We learned that `SetPosition` is bad for continually calling during any Periodic function because it can potentially wait up to 50 ms.

I tested this out on the tabletop RIO and had success with it. This seems to be more in line with the expected usage of limit switches for [the Phoenix6 API](https://v6.docs.ctr-electronics.com/en/stable/docs/api-reference/api-usage/actuator-limits.html). Have a look and see what you think.