### PR TITLE
Post a boolean to SmartDashboard if the bot is aligned with the chain

### DIFF
--- a/src/main/cpp/Gyro.cpp
+++ b/src/main/cpp/Gyro.cpp
@@ -31,13 +31,15 @@ void Gyro::Init() {
 }
 
 void Gyro::Cal() {
-    
+
 }
 
 void Gyro::Update() {
-
-    //frc::SmartDashboard::PutNumber("gyro angle: ", getAngle());
     frc::SmartDashboard::PutNumber("gyro angle clamped: ", getAngleClamped());
+
+    // Posts a boolean to SmartDashboard to allow a big red or green square to indicate if the robot
+    // is aligned with 1 of the 3 angles for the stage chain
+    frc::SmartDashboard::PutBoolean("Chain Aligned", IsAlignedWithChain());
 }
 
 double Gyro::getAngle() const {
@@ -62,4 +64,34 @@ double Gyro::getAbsoluteCompassHeading () const{
 
 void Gyro::Zero(double offsetAngle) { //takes offsetAngle, defaults to zero if none provided. CCW is +
     a_PigeonIMU.SetYaw(0);
+}
+
+/**
+ * 2024 Crescendo function to return a simple boolean if the robot is aligned with
+ * 1 of the 3 angles to hang on the chain for the stage. This cannot tell if the robot
+ * is in the right location on the field. It is purely for lining up the angle.
+*/
+bool Gyro::IsAlignedWithChain() {
+    static const double kToleranceDegrees = 4.0;
+    static const std::array<double, 3> kChainAngleDegrees = {
+        0.0,
+        60.0,
+        300.0
+    };
+
+    double current_angle = getAngleClamped();
+
+    // If the angle of the robot is near 360, shift it down so the simple
+    // subtraction and fabs check will handle the tolerance check correctly
+    if (current_angle + kToleranceDegrees >= 360) {
+        current_angle -= 360.0;
+    }
+
+    for (double chain_angle : kChainAngleDegrees) {
+        if (fabs(current_angle - chain_angle) < kToleranceDegrees) {
+            return true;
+        }
+    }
+
+    return false;
 }

--- a/src/main/include/Gyro.h
+++ b/src/main/include/Gyro.h
@@ -31,6 +31,10 @@ class Gyro {
         double getAngleClamped() const;
         void Zero(double offsetAngle = 0); // takes offsetAngle, defaults to zero if none provided. CCW is +
 
+        // 2024 Crescendo function to return a simple boolean if the robot is aligned with 1 of the 3 angles
+        // to hang on the chain for the stage
+        bool IsAlignedWithChain();
+
     private:
         double angle[3];
         double angleBias[3];


### PR DESCRIPTION
To help align the bot with the angle of the chain without being able to see the April Tags, this uses the gyro angle to provide a quick reference for whether the bot is aligned with one of the 3 angles. On SmartDashboard, the boolean field can be changed to display a simple red or green box based on the boolean input value.